### PR TITLE
Implement buildutils / modutils

### DIFF
--- a/buildutils/alias.go
+++ b/buildutils/alias.go
@@ -1,0 +1,23 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildutils
+
+var (
+	// DefaultBuilder is the default Builder.
+	DefaultBuilder = Builder{}
+
+	// Build is an alias for DefaultBuilder.Build.
+	Build = DefaultBuilder.Build
+)

--- a/buildutils/buildutils.go
+++ b/buildutils/buildutils.go
@@ -1,0 +1,77 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildutils
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Builder is a builder for go code.
+type Builder struct {
+	dir  string
+	tidy bool
+}
+
+func (b *Builder) execCommand(name string, args ...string) error {
+	var buf bytes.Buffer
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	cmd.Dir = b.dir
+
+	cmdString := strings.Join(append([]string{name}, args...), " ")
+	if err := cmd.Run(); err != nil {
+		err = fmt.Errorf("error running %s: %w", cmdString, err)
+		if output := buf.String(); output != "" {
+			return fmt.Errorf("%w, output:\n%s", err, output)
+		}
+		return err
+	}
+	return nil
+}
+
+// Build runs `go build` with the target output and name.
+// If BuilderOptions.Tidy was set, it runs `go mod tidy` beforehand.
+func (b *Builder) Build(name, filename string) error {
+	if b.tidy {
+		if err := b.execCommand("go", "mod", "tidy"); err != nil {
+			return fmt.Errorf("error tidying: %w", err)
+		}
+	}
+
+	if err := b.execCommand("go", "build", "-o", filename, name); err != nil {
+		return fmt.Errorf("error building: %w", err)
+	}
+	return nil
+}
+
+// BuilderOptions are options to create a builder with.
+type BuilderOptions struct {
+	// Dir is the working directory for the Builder.
+	Dir string
+	// Tidy can specify whether the builder should run `go mod tidy` before building.
+	Tidy bool
+}
+
+// NewBuilder creates a new Builder with the given options.
+func NewBuilder(opts BuilderOptions) *Builder {
+	return &Builder{
+		dir:  opts.Dir,
+		tidy: opts.Tidy,
+	}
+}

--- a/modutils/alias.go
+++ b/modutils/alias.go
@@ -1,0 +1,40 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modutils
+
+var (
+	// DefaultExecutor is the default executor.
+	DefaultExecutor = &Executor{}
+
+	// ListE is an alias to DefaultExecutor.ListE.
+	ListE = DefaultExecutor.ListE
+	// List is an alias to DefaultExecutor.List.
+	List = DefaultExecutor.List
+
+	// GetE is an alias to DefaultExecutor.GetE.
+	GetE = DefaultExecutor.GetE
+	// Get is an alias to DefaultExecutor.Get.
+	Get = DefaultExecutor.Get
+
+	// GetDirE is an alias to DefaultExecutor.GetDirE.
+	GetDirE = DefaultExecutor.DirE
+	// GetDir is an alias to DefaultExecutor.GetDir.
+	GetDir = DefaultExecutor.Dir
+
+	// BuildE is an alias to DefaultExecutor.BuildE.
+	BuildE = DefaultExecutor.BuildE
+	// Build is an alias to DefaultExecutor.Build.
+	Build = DefaultExecutor.Build
+)

--- a/modutils/modutils.go
+++ b/modutils/modutils.go
@@ -1,0 +1,251 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/onmetal/controller-utils/buildutils"
+)
+
+// Executor is an executor for go.mod-related operations.
+type Executor struct {
+	dir string
+}
+
+// ExecutorOptions are options to create an executor with.
+type ExecutorOptions struct {
+	// Dir is the working directory the executor runs in.
+	Dir string
+}
+
+// NewExecutor creates a new Executor with the given ExecutorOptions.
+func NewExecutor(opts ExecutorOptions) *Executor {
+	return &Executor{dir: opts.Dir}
+}
+
+// Module is a module read from a go.mod file and its dependencies.
+type Module struct {
+	Path      string
+	Version   string
+	Replace   *Module
+	Time      time.Time
+	Indirect  bool
+	Main      bool
+	Dir       string
+	GoMod     string
+	GoVersion string
+}
+
+func (e *Executor) execGoModList(pattern string) ([]Module, error) {
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+	cmd := exec.Command("go", "list", "-json", "-m", pattern)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Dir = e.dir
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("error executing go mod list -m %s:\n\n%s", pattern, stderr.String())
+	}
+
+	var modules []Module
+	dec := json.NewDecoder(&stdout)
+	for dec.More() {
+		var mod Module
+		if err := dec.Decode(&mod); err != nil {
+			return nil, fmt.Errorf("error decoding module: %w", err)
+		}
+
+		modules = append(modules, mod)
+	}
+	return modules, nil
+}
+
+// ListE lists all modules of the current module.
+func (e *Executor) ListE() ([]Module, error) {
+	return e.execGoModList("all")
+}
+
+// List lists all modules of the current module. It panics if an error occurs.
+func (e *Executor) List() []Module {
+	mods, err := e.ListE()
+	if err != nil {
+		panic(err)
+	}
+	return mods
+}
+
+// GetE gets the module with the specified name.
+func (e *Executor) GetE(name string) (*Module, error) {
+	mods, err := e.execGoModList(name)
+	if err != nil {
+		return nil, fmt.Errorf("error loading modules: %w", err)
+	}
+
+	for _, mod := range mods {
+		if mod.Path != name {
+			continue
+		}
+
+		mod := mod
+		return &mod, nil
+	}
+	return nil, fmt.Errorf("module %q not found", name)
+}
+
+// Get gets the module with the specified name.
+// It panics if an error occurs.
+func (e *Executor) Get(name string) *Module {
+	mod, err := e.GetE(name)
+	if err != nil {
+		panic(err)
+	}
+	return mod
+}
+
+// DirE gets the on-disk location of the specified module, optionally joining the parts to the directory.
+func (e *Executor) DirE(name string, parts ...string) (string, error) {
+	mod, err := e.GetE(name)
+	if err != nil {
+		return "", fmt.Errorf("error getting module: %w", err)
+	}
+	if mod.Dir == "" {
+		return "", fmt.Errorf("module %s does not specify a directory", name)
+	}
+
+	if len(parts) == 0 {
+		return mod.Dir, nil
+	}
+	return filepath.Join(append([]string{mod.Dir}, parts...)...), nil
+}
+
+// Dir gets the on-disk location of the specified module, optionally joining the parts to the directory.
+// It panics if an error occurs.
+func (e *Executor) Dir(name string, parts ...string) string {
+	dir, err := e.DirE(name, parts...)
+	if err != nil {
+		panic(err)
+	}
+	return dir
+}
+
+func (e *Executor) copy(src, dst string) error {
+	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, 0777)
+		} else {
+			return copyFile(path, dstPath)
+		}
+	})
+}
+
+func copyFile(srcFilename, dstFilename string) error {
+	srcFile, err := os.Open(srcFilename)
+	if err != nil {
+		return fmt.Errorf("error opening source file %s: %w", srcFilename, err)
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	srcStat, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("error stat-ing source file %s: %w", srcFilename, err)
+	}
+
+	dstFile, err := os.OpenFile(dstFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcStat.Mode()|0666)
+	if err != nil {
+		return fmt.Errorf("error creating destination file %s: %w", dstFilename, err)
+	}
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		_ = dstFile.Close()
+		_ = os.Remove(dstFilename)
+		return fmt.Errorf("error copying from source file %s to destination file %s: %w", srcFilename, dstFilename, err)
+	}
+
+	if err := dstFile.Close(); err != nil {
+		_ = os.Remove(dstFilename)
+		return fmt.Errorf("error closing destination file %s: %w", dstFilename, err)
+	}
+	return nil
+}
+
+// BuildE builds the specified module to the target filename, optionally taking sub-paths in the target module.
+func (e *Executor) BuildE(filename, name string, parts ...string) error {
+	dir, err := e.DirE(name)
+	if err != nil {
+		return fmt.Errorf("error getting directory of %s: %w", name, err)
+	}
+
+	target := "."
+	if len(parts) > 0 {
+		target += path.Join(parts...)
+	}
+
+	if err := e.build(name, dir, target, filename); err != nil {
+		return fmt.Errorf("error building %s: %w", name, err)
+	}
+	return nil
+}
+
+// Build builds the specified module to the target filename, optionally taking sub-paths in the target module.
+// It panics if an error occurs.
+func (e *Executor) Build(filename, name string, parts ...string) {
+	if err := e.BuildE(filename, name, parts...); err != nil {
+		panic(err)
+	}
+}
+
+func (e *Executor) build(name, dir, target, filename string) error {
+	buildDir, err := os.MkdirTemp("", "build-")
+	if err != nil {
+		return fmt.Errorf("error creating temp directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(buildDir) }()
+
+	if err := e.copy(dir, buildDir); err != nil {
+		return fmt.Errorf("error copying module to build directory: %w", err)
+	}
+
+	bldr := buildutils.NewBuilder(buildutils.BuilderOptions{
+		Dir:  buildDir,
+		Tidy: true,
+	})
+
+	if err := bldr.Build(target, filename); err != nil {
+		return fmt.Errorf("error building %s (target %s): %w", name, target, err)
+	}
+	return nil
+}

--- a/modutils/modutils_suite_test.go
+++ b/modutils/modutils_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestModutils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Modutils Suite")
+}

--- a/modutils/modutils_test.go
+++ b/modutils/modutils_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modutils_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	. "github.com/onmetal/controller-utils/modutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Modutils", func() {
+	Context("Executor", func() {
+		var (
+			executor *Executor
+		)
+		BeforeEach(func() {
+			executor = NewExecutor(ExecutorOptions{Dir: "../testdata/testmod1"})
+		})
+
+		Describe("ListE", func() {
+			It("should list all modules", func() {
+				res, err := executor.ListE()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(ConsistOf(
+					HaveField("Path", "example.org/testmod1"),
+					HaveField("Path", "example.org/testmod2"),
+				))
+			})
+		})
+
+		Describe("GetE", func() {
+			It("should get the specified module", func() {
+				res, err := executor.GetE("example.org/testmod2")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(HaveField("Path", "example.org/testmod2"))
+			})
+		})
+
+		Describe("DirE", func() {
+			It("should get the directory of the specified module", func() {
+				dir, err := executor.DirE("example.org/testmod2")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dir).To(BeADirectory())
+				Expect(filepath.Join(dir, "go.mod")).To(BeARegularFile())
+				Expect(filepath.Join(dir, "main.go")).To(BeARegularFile())
+			})
+		})
+
+		Describe("BuildE", func() {
+			It("should build the module via another module", func() {
+				dstFilename := filepath.Join(GinkgoT().TempDir(), "hello-world")
+				Expect(executor.BuildE(dstFilename, "example.org/testmod2")).To(Succeed())
+
+				session, err := gexec.Start(exec.Command(dstFilename), GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(session.Wait(1 * time.Second).Out).To(gbytes.Say("Hello, World!"))
+			})
+		})
+	})
+})

--- a/testdata/testmod1/go.mod
+++ b/testdata/testmod1/go.mod
@@ -1,0 +1,7 @@
+module example.org/testmod1
+
+go 1.17
+
+replace example.org/testmod2 => ./../testmod2
+
+require example.org/testmod2 v0.0.0-00010101000000-000000000000

--- a/testdata/testmod2/go.mod
+++ b/testdata/testmod2/go.mod
@@ -1,0 +1,3 @@
+module example.org/testmod2
+
+go 1.17

--- a/testdata/testmod2/main.go
+++ b/testdata/testmod2/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}


### PR DESCRIPTION
The utilities simplify building code from modules. This is especially
relevant when building dependcies for local use during testing.