### PR TITLE
Add `GetOptions` to client GET method

### DIFF
--- a/memorystore/memorystore.go
+++ b/memorystore/memorystore.go
@@ -111,7 +111,13 @@ func (s *Store) Create(_ context.Context, obj client.Object, opts ...client.Crea
 }
 
 // Get implements client.Get.
-func (s *Store) Get(_ context.Context, objectKey client.ObjectKey, obj client.Object) error {
+func (s *Store) Get(_ context.Context, objectKey client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	o := &client.GetOptions{}
+	o.ApplyOptions(opts)
+	if err := validateClientGetOptions(o); err != nil {
+		return err
+	}
+
 	key, err := clientutils.ObjectRefFromObject(s.scheme, obj)
 	if err != nil {
 		return err
@@ -127,6 +133,13 @@ func (s *Store) Get(_ context.Context, objectKey client.ObjectKey, obj client.Ob
 	}
 
 	return s.scheme.Convert(v, obj, nil)
+}
+
+func validateClientGetOptions(opts *client.GetOptions) error {
+	if opts.Raw != nil {
+		return fmt.Errorf("raw is not supported")
+	}
+	return nil
 }
 
 func validateClientListOptions(opts *client.ListOptions) error {


### PR DESCRIPTION
# Proposed Changes

As the client interface has changed with kube 1.26 the `GetOptions` has now to be passed in the GET method.

Otherwise you might end up with the following error:
```
cannot use s (variable of type *memorystore.Store) as client.Client value in argument to utils.GetSecretSelector: *memorystore.Store does not implement client.Client (wrong type for method Get)
                have Get(_ context.Context, objectKey types.NamespacedName, obj client.Object) error
                want Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error (typecheck)
```
